### PR TITLE
added generator to cmake --build

### DIFF
--- a/cmake/HunterGate.cmake
+++ b/cmake/HunterGate.cmake
@@ -304,7 +304,7 @@ function(hunter_gate_download dir)
       "  -> ${dir}"
   )
   execute_process(
-      COMMAND "${CMAKE_COMMAND}" --build "${build_dir}"
+      COMMAND "${CMAKE_COMMAND}" "-G${CMAKE_GENERATOR}" --build "${build_dir}"
       WORKING_DIRECTORY "${dir}"
       RESULT_VARIABLE download_result
       ${logging_params}


### PR DESCRIPTION
Generator required when cmake builds projects from the command line (e.g. on CI servers using MSBuild.exe)