### PR TITLE
Require CMake 3.0 only when HUNTER_ENABLED is ON

### DIFF
--- a/cmake/HunterGate.cmake
+++ b/cmake/HunterGate.cmake
@@ -42,10 +42,16 @@
 #     * https://github.com/hunter-packages/gate/
 #     * https://github.com/ruslo/hunter
 
-cmake_minimum_required(VERSION 3.0) # Minimum for Hunter
+option(HUNTER_ENABLED "Enable Hunter package manager support" ON)
+if(HUNTER_ENABLED)
+  if(CMAKE_VERSION VERSION_LESS "3.0")
+    message(FATAL_ERROR "At least CMake version 3.0 required for hunter dependency management."
+      " Update CMake or set HUNTER_ENABLED to OFF.")
+  endif()
+endif()
+
 include(CMakeParseArguments) # cmake_parse_arguments
 
-option(HUNTER_ENABLED "Enable Hunter package manager support" ON)
 option(HUNTER_STATUS_PRINT "Print working status" ON)
 option(HUNTER_STATUS_DEBUG "Print a lot info" OFF)
 


### PR DESCRIPTION
Only require CMake 3.0 as minimum version if Hunter is actually enabled. Otherwise the developer is responsible for its dependencies.

Enables to have the same codebase on Ubuntu 14.04 (with cmake 2.8.11) and newer versions. A developer on older cmake version has to get his dependencies himself, on newer versions of CMake Hunter can be used